### PR TITLE
Add FanProxy contract placeholder

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "solhint:recommended"
+  "extends": "solhint:recommended",
+  "rules": {
+    "compiler-version": "off"
+  }
 }

--- a/client/src/components/Fan.js
+++ b/client/src/components/Fan.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { Button, Card, Form, InputGroup } from "react-bootstrap";
 import Web3 from "web3";
-import SimpleStorageContract from "../contracts/SimpleStorage.json";
+import FanProxyContract from "../contracts/FanProxy.json";
 import TransactionModal, { TransactionModalState } from "./TransactionModal";
 import "./Fan.css";
 
@@ -46,11 +46,9 @@ class Fan extends Component {
     try {
       const web3 = new Web3(provider);
       const networkId = await web3.eth.net.getId();
-      // TODO: Replace with fan donation contract.
-      const deployedNetwork = SimpleStorageContract.networks[networkId];
+      const deployedNetwork = FanProxyContract.networks[networkId];
       const instance = new web3.eth.Contract(
-        // TODO: Replace with fan donation contract abi.
-        SimpleStorageContract.abi,
+        FanProxyContract.abi,
         deployedNetwork && deployedNetwork.address
       );
 
@@ -90,10 +88,9 @@ class Fan extends Component {
 
     try {
       this.state.contract.methods
-        .set(5)
-        .send({ from: this.props.connectedWallet, amount: this.getEthAmount() })
+        .swapAndDonateEth(this.state.creatorAddress)
+        .send({ from: this.props.connectedWallet, value: this.getEthAmount() })
         .once("transactionHash", (hash) => {
-          console.log(hash);
           this.setState({
             sentTransactionHash: hash,
             transactionModalState: TransactionModalState.AWAITING_CONFIRMATION,

--- a/contracts/FanProxy.sol
+++ b/contracts/FanProxy.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract FanProxy {
+    function swapAndDonateEth(address to) external payable {
+        require(msg.value > 0, "Cannot swap and donate 0 ETH");
+
+        // TODO: Remove this. Just for testing purposes.
+        (bool success, ) = to.call{value: msg.value}("");
+        require(success, "Transfer failed");
+
+        // TODO: Swap ETH to USDC via FanSwap contract.
+
+        // Should be the amount of USDC this contract has after FanSwap.swap().
+        // Replace with IERC20(usdcAddress).balanceOf(address(this)).
+        uint256 usdcAmount = 100;
+        _donate(usdcAmount, to);
+    }
+
+    function _donate(uint256 usdcAmount, address to) private {
+        require(usdcAmount > 0, "Cannot donate 0 USDC");
+        // TODO: Remove require statement. Added to satisfy "unused var" linter.
+        require(to != address(0), "Required just to use var");
+
+        // TODO: Approve FanDonation contract to spend usdcAmount.
+        // TODO: Call FanDonation.donate(usdcAmount, to);
+    }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,7 @@
 var SimpleStorage = artifacts.require("./SimpleStorage.sol");
+var FanProxy = artifacts.require("./FanProxy.sol");
 
 module.exports = function (deployer) {
   deployer.deploy(SimpleStorage);
+  deployer.deploy(FanProxy);
 };

--- a/test/fanproxy.js
+++ b/test/fanproxy.js
@@ -1,0 +1,19 @@
+const FanProxy = artifacts.require("./FanProxy.sol");
+
+contract("FanProxy", (accounts) => {
+  // This is not a real test for FanProxy final behavior.
+  it("should send eth to creator address", async () => {
+    const fanProxyInstance = await FanProxy.deployed();
+    const fanAddress = accounts[0];
+    const creatorAddress = accounts[1];
+    const ethDonationAmount = web3.utils.toWei("5");
+
+    await fanProxyInstance.swapAndDonateEth(creatorAddress, {
+      from: fanAddress,
+      value: ethDonationAmount,
+    });
+
+    const creatorBalance = await web3.eth.getBalance(creatorAddress);
+    assert.equal(creatorBalance, web3.utils.toWei("105"));
+  });
+});


### PR DESCRIPTION
The contract does not yet contain actual behavior. The contract currently sends ETH to the creator's address for testing purposes.

- Adds FanProxy stub contract with test
- Uses FanProxy.swapAndDonateEth on Fan page when sending a donation
