### PR TITLE
Add FanSwap contract in FanProxy

### DIFF
--- a/contracts/FanProxy.sol
+++ b/contracts/FanProxy.sol
@@ -17,7 +17,7 @@ contract FanProxy {
         fanSwap = FanSwap(fanSwapAddress);
     }
 
-    function swapAndDonateEth(address to) external payable {
+    function swapAndDonateETH(address to) external payable {
         require(msg.value > 0, "Cannot swap and donate 0 ETH");
 
         fanSwap.swapToUSDC{value: msg.value}();

--- a/contracts/FanProxy.sol
+++ b/contracts/FanProxy.sol
@@ -7,7 +7,7 @@ import "./FanSwap.sol";
 contract FanProxy {
     // USDC address compatible with Aave for aUSDC.
     address private constant USDC_KOVAN_ADDRESS =
-        0xe22da380ee6b445bb8273c81944adeb6e8450422;
+        0xe22da380ee6B445bb8273C81944ADEB6E8450422;
 
     IERC20 private usdc = IERC20(USDC_KOVAN_ADDRESS);
 

--- a/contracts/FanProxy.sol
+++ b/contracts/FanProxy.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "./FanDonation.sol";
 import "./FanSwap.sol";
 
 contract FanProxy {
@@ -9,12 +10,14 @@ contract FanProxy {
     address private constant USDC_KOVAN_ADDRESS =
         0xe22da380ee6B445bb8273C81944ADEB6E8450422;
 
-    IERC20 private usdc = IERC20(USDC_KOVAN_ADDRESS);
+    ERC20 private usdc = ERC20(USDC_KOVAN_ADDRESS);
 
     FanSwap private immutable fanSwap;
+    FanDonation private immutable fanDonation;
 
-    constructor(address fanSwapAddress) public {
+    constructor(address fanSwapAddress, address fanDonationAddress) public {
         fanSwap = FanSwap(fanSwapAddress);
+        fanDonation = FanDonation(fanDonationAddress);
     }
 
     function swapAndDonateETH(address to) external payable {
@@ -30,10 +33,7 @@ contract FanProxy {
 
     function _donateUSDC(uint256 amount, address to) private {
         require(amount > 0, "Cannot donate 0 USDC");
-        // TODO: Remove require statement. Added to satisfy "unused var" linter.
-        require(to != address(0), "Required just to use var");
-
-        // TODO: Approve FanDonation contract to spend usdcAmount.
-        // TODO: Call FanDonation.donate(usdcAmount, to);
+        usdc.increaseAllowance(address(fanDonation), amount);
+        fanDonation.donate(amount, to);
     }
 }

--- a/contracts/FanProxy.sol
+++ b/contracts/FanProxy.sol
@@ -20,14 +20,16 @@ contract FanProxy {
     function swapAndDonateETH(address to) external payable {
         require(msg.value > 0, "Cannot swap and donate 0 ETH");
 
+        // Swaps ETH for USDC. Swapped USDC is returned to this contract, which
+        // will be donated within the same transaction.
         fanSwap.swapToUSDC{value: msg.value}();
 
-        uint256 swappedUsdcAmount = usdc.balanceOf(address(this));
-        _donate(swappedUsdcAmount, to);
+        uint256 swappedUSDCAmount = usdc.balanceOf(address(this));
+        _donateUSDC(swappedUSDCAmount, to);
     }
 
-    function _donate(uint256 usdcAmount, address to) private {
-        require(usdcAmount > 0, "Cannot donate 0 USDC");
+    function _donateUSDC(uint256 amount, address to) private {
+        require(amount > 0, "Cannot donate 0 USDC");
         // TODO: Remove require statement. Added to satisfy "unused var" linter.
         require(to != address(0), "Required just to use var");
 

--- a/contracts/FanSwap.sol
+++ b/contracts/FanSwap.sol
@@ -10,7 +10,7 @@ contract FanSwap {
         0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
     // USDC address compatible with Aave for aUSDC.
     address private constant USDC_KOVAN_ADDRESS =
-        0xe22da380ee6b445bb8273c81944adeb6e8450422;
+        0xe22da380ee6B445bb8273C81944ADEB6E8450422;
 
     IUniswapV2Router02 private uniswapRouter =
         IUniswapV2Router02(UNISWAP_ROUTER_ADDRESS);

--- a/contracts/FanSwap.sol
+++ b/contracts/FanSwap.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
+
+contract FanSwap {
+    // Uniswap address on mainnet and testnets.
+    address private constant UNISWAP_ROUTER_ADDRESS =
+        0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
+    // USDC address compatible with Aave for aUSDC.
+    address private constant USDC_KOVAN_ADDRESS =
+        0xe22da380ee6b445bb8273c81944adeb6e8450422;
+
+    IUniswapV2Router02 private uniswapRouter =
+        IUniswapV2Router02(UNISWAP_ROUTER_ADDRESS);
+    IERC20 private usdc = IERC20(USDC_KOVAN_ADDRESS);
+
+    function swapToUSDC() external payable {
+        require(msg.value > 0, "Cannot swap 0 ETH");
+
+        // Minimum amount of USDC from the swap to be considered successful.
+        uint256 amountOutMin = 0;
+
+        // Approximately now for convenience on testnets.
+        // On mainnet, this should be passed from frontend.
+        uint256 deadline = block.timestamp + 15;
+
+        // Swaps ETH from sender to USDC and sends swapped USDC back to sender.
+        uniswapRouter.swapExactETHForTokens{value: msg.value}(
+            amountOutMin,
+            getPathForETHToUSDC(),
+            msg.sender,
+            deadline
+        );
+    }
+
+    function getPathForETHToUSDC() private view returns (address[] memory) {
+        address[] memory path = new address[](2);
+        path[0] = uniswapRouter.WETH();
+        path[1] = USDC_KOVAN_ADDRESS;
+        return path;
+    }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,6 +1,7 @@
 var SimpleStorage = artifacts.require("./SimpleStorage.sol");
-var FanProxy = artifacts.require("./FanProxy.sol");
 const FanDonation = artifacts.require("./FanDonation.sol");
+const FanProxy = artifacts.require("./FanProxy.sol");
+const FanSwap = artifacts.require("./FanSwap.sol");
 
 // 0x88757f2f99175387ab4c6a4b3067c77a695b0349 is the address for LendingPoolAddressesProvider
 // on Kovan. (https://docs.aave.com/developers/deployed-contracts)
@@ -9,6 +10,8 @@ const LendingPoolAddressesProvider =
 
 module.exports = function (deployer) {
   deployer.deploy(SimpleStorage);
-  deployer.deploy(FanProxy);
   deployer.deploy(FanDonation, LendingPoolAddressesProvider);
+  deployer.deploy(FanSwap).then(() => {
+    return deployer.deploy(FanProxy, FanSwap.address, FanDonation.address);
+  });
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "dependencies": {
     "@aave/protocol-v2": "^1.0.1",
-    "@openzeppelin/contracts": "^3.3.0"
+    "@openzeppelin/contracts": "^3.3.0",
+    "@uniswap/v2-core": "^1.0.1",
+    "@uniswap/v2-periphery": "^1.1.0-beta.0"
   },
   "devDependencies": {
     "husky": "^4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,6 +2832,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/lib@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@uniswap/lib@npm:1.1.1"
+  checksum: ee80fdc930b63339b2d6fb6ea58b74a913942f238294b66c815666c93ebaba536fb9628147325892957fa479104149fc8e935faa0d62d9dcb7193c54e5cd34cf
+  languageName: node
+  linkType: hard
+
+"@uniswap/v2-core@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@uniswap/v2-core@npm:1.0.0"
+  checksum: 616c8a32ccf25db1b8d5708c2fc7f66795a4ff226d3a2268a97573534aab73e4f59f8f07cc5ae820852a7dfb8e9f23b856b8f443afdee65cd09f931ec9b58cda
+  languageName: node
+  linkType: hard
+
+"@uniswap/v2-core@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@uniswap/v2-core@npm:1.0.1"
+  checksum: e3dcbe72500530249b68d2f2c92062f3f21919267123262578a34cac2862edf7eeda8fcdc808a370d109f26e357635b1cf546e35dbd902a18768ac88d9a8fb0f
+  languageName: node
+  linkType: hard
+
+"@uniswap/v2-periphery@npm:^1.1.0-beta.0":
+  version: 1.1.0-beta.0
+  resolution: "@uniswap/v2-periphery@npm:1.1.0-beta.0"
+  dependencies:
+    "@uniswap/lib": 1.1.1
+    "@uniswap/v2-core": 1.0.0
+  checksum: fcfe52df7cf410738cde25684585cc454cd879f245b671b2686e65a3ffd7c109cbb0bbb89f82a04fe1d08711481f9c91a350ab8bc92b645dd99f1d58a1a18d8b
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/ast@npm:1.8.5"
@@ -3035,6 +3066,8 @@ __metadata:
     "@aave/protocol-v2": ^1.0.1
     "@openzeppelin/contracts": ^3.3.0
     "@truffle/hdwallet-provider": ^1.2.1
+    "@uniswap/v2-core": ^1.0.1
+    "@uniswap/v2-periphery": ^1.1.0-beta.0
     husky: ^4.3.8
     lint-staged: ^10.5.3
     prettier: 2.2.1


### PR DESCRIPTION
Calls Uniswap to swap ETH for USDC. Swapped USDC is sent to FanProxy, which is then donated by FanDonation.

- Updates FanProxy to use FanSwap and FanDonation