### PR TITLE
Shorten creator fan link to remove query param

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -86,7 +86,7 @@ class App extends Component {
         <Switch>
           <Route exact path="/" component={Home} />
           <Route
-            path="/fan"
+            path={["/fan/:creatorAddress", "/fan"]}
             render={(routeProps) => (
               <Fan
                 {...routeProps}

--- a/client/src/components/Creator.js
+++ b/client/src/components/Creator.js
@@ -98,8 +98,7 @@ class Creator extends Component {
 
   render() {
     const balance = this.state.aUSDCBalance + " aUSDC";
-    const fanLink =
-      "https://blossym.org/fan?creatorAddress=" + this.props.connectedWallet;
+    const fanLink = "https://blossym.org/fan/" + this.props.connectedWallet;
 
     let page;
     if (!this.props.connectedWallet) {

--- a/client/src/components/Fan.js
+++ b/client/src/components/Fan.js
@@ -23,13 +23,10 @@ class Fan extends Component {
   }
 
   componentDidMount = async () => {
-    if (!this.props.location) {
-      return;
+    const creatorAddressFromUrl = this.props.match.params.creatorAddress;
+    if (creatorAddressFromUrl) {
+      this.setState({ creatorAddress: creatorAddressFromUrl });
     }
-    // Populates creator address input field with value from URL query param.
-    const queryParams = new URLSearchParams(this.props.location.search);
-    const creatorAddress = queryParams.get("creatorAddress");
-    this.setState({ creatorAddress: creatorAddress });
   };
 
   componentDidUpdate = async (prevProps) => {

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 
 class Home extends Component {
   getCreatorCard(name, description, address, websiteUrl) {
-    const fanLink = "/fan?creatorAddress=" + address;
+    const fanLink = "/fan/" + address;
     return (
       <Card>
         <Card.Body>


### PR DESCRIPTION
Use route param instead of query param for fan link.

Before:
https://blossym.org/fan?creatorAddress=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045

After (no query param):
https://blossym.org/fan/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
