### PR TITLE
Update home fan and creator buttons

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -11,10 +11,12 @@ class Home extends Component {
           <Card.Title>{name}</Card.Title>
           <Card.Text>{description}</Card.Text>
           <Link to={fanLink}>
-            <Button variant="info">Support</Button>
+            <Button className="mr-2 mt-1" variant="info">
+              Support
+            </Button>
           </Link>
           <Button
-            className="ml-2"
+            className="mt-1"
             variant="secondary"
             href={websiteUrl}
             target="_blank"

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -36,7 +36,7 @@ class Home extends Component {
           <p className="lead">The crypto way to fund the creative economy.</p>
           <div className="mt-4">
             <Link className="mr-4" to="/fan">
-              <Button variant="primary" size="lg">
+              <Button variant="info" size="lg">
                 Fans
               </Button>
             </Link>

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -34,24 +34,30 @@ class Home extends Component {
         <Jumbotron className="text-center">
           <h1 className="display-4">Welcome to Blossym!</h1>
           <p className="lead">The crypto way to fund the creative economy.</p>
-          <div className="mt-4">
-            <Link className="mr-4" to="/fan">
-              <Button variant="info" size="lg">
-                Fans
-              </Button>
-            </Link>
-            <Link className="ml-4" to="/creator">
-              <Button variant="success" size="lg">
-                Creators
-              </Button>
-            </Link>
+          <div className="mt-4 d-flex justify-content-center">
+            <div className="d-flex flex-column align-items-center mr-4">
+              <h2 class="h5">Fans</h2>
+              <Link to="/fan">
+                <Button variant="info" size="lg">
+                  Support creators
+                </Button>
+              </Link>
+            </div>
+            <div className="d-flex flex-column align-items-center">
+              <h2 class="h5">Creators</h2>
+              <Link to="/creator">
+                <Button variant="success" size="lg">
+                  Open dashboard
+                </Button>
+              </Link>
+            </div>
           </div>
         </Jumbotron>
         <Container className="mt-5">
           <CardDeck className="mt-4">
             {this.getCreatorCard(
               "DeFi Dad",
-              "DeFi content creator",
+              "Content creator",
               "0x2f71129b240080C638ac8d993BFF52169E3551c3",
               "https://twitter.com/DeFi_Dad"
             )}
@@ -63,7 +69,7 @@ class Home extends Component {
             )}
             {this.getCreatorCard(
               "Vitalik Buterin",
-              "Co-founder of Ethereum",
+              "Ethereum co-founder",
               "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
               "https://vitalik.ca"
             )}


### PR DESCRIPTION
- Make buttons verb-based: "Fan" -> "Support creators", "Creator" -> "Open dashboard".
- Add fan and creator label above buttons
- Make fan button purple to match "Support" creator buttons in cards below

![Screenshot_2021-02-06 Blossym(6)](https://user-images.githubusercontent.com/2449384/107130650-9a61bb00-6884-11eb-9abf-1b08f5263fe8.png)

Before:
![Screenshot_2021-02-06 Blossym(7)](https://user-images.githubusercontent.com/2449384/107130654-9c2b7e80-6884-11eb-8f1d-688816f2e095.png)