### PR TITLE
Fix race condition when loading transactions

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -12,6 +12,7 @@ const initialState = {
   web3: null,
   provider: null,
   connectedWallet: "",
+  ethTransactions: [],
 };
 
 const providerOptions = {
@@ -59,9 +60,8 @@ class App extends Component {
         process.env.ETHERSCAN_KEY;
       const response = await fetch(fetchURL);
       const responseJson = await response.json();
-      // First 5 only.
-      const ethTransactions = responseJson.result.slice(0, 5);
-      this.setState({ ethTransactions: ethTransactions });
+      // First 5 transactions only.
+      this.setState({ ethTransactions: responseJson.result.slice(0, 5) });
     }
   }
 
@@ -79,8 +79,8 @@ class App extends Component {
       <BrowserRouter>
         <NavHeader
           connectedWallet={this.state.connectedWallet}
-          onWalletConnectClick={() => this.openWalletConnectModal()}
-          onDisconnectWallet={() => this.disconnectWallet()}
+          onWalletConnectClick={this.openWalletConnectModal}
+          onDisconnectWallet={this.disconnectWallet}
         />
         <Switch>
           <Route exact path="/" component={Home} />

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -57,12 +57,11 @@ class App extends Component {
         this.state.connectedWallet +
         "&startblock=0&endblock=99999999&sort=desc&apikey=" +
         process.env.ETHERSCAN_KEY;
-      fetch(fetchURL)
-        .then((response) => response.json())
-        .then((ethTx) => {
-          ethTx = ethTx.result.slice(0, 5);
-          this.setState({ ethTransactions: ethTx });
-        });
+      const response = await fetch(fetchURL);
+      const responseJson = await response.json();
+      // First 5 only.
+      const ethTransactions = responseJson.result.slice(0, 5);
+      this.setState({ ethTransactions: ethTransactions });
     }
   }
 


### PR DESCRIPTION
The creator page would sometimes open before the ethTransactions state value was loaded/set.

- Set a default value, `[]`, for the transactions
- Await transactions instead of using callbacks when retrieving transactions
