### PR TITLE
Fix disconnect wallet

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -35,6 +35,7 @@ class App extends Component {
       providerOptions, // required
     });
     this.openWalletConnectModal = this.openWalletConnectModal.bind(this);
+    this.disconnectWallet = this.disconnectWallet.bind(this);
   }
 
   async openWalletConnectModal() {


### PR DESCRIPTION
Without binding `this`, the function would throw an error stating it cannot find `web3` from `this.state`.
