### PR TITLE
Fix issue where interest time period is not preselected

### DIFF
--- a/client/src/components/Creator.js
+++ b/client/src/components/Creator.js
@@ -51,8 +51,9 @@ class Creator extends Component {
     const estimatedBalance = principle * (1 + rate * timeYears);
     return estimatedBalance;
   }
-  changeEstValue(e) {
-    const estimatedBalance = this.calculateInterest(e.target.value);
+
+  changeEstValue(value) {
+    const estimatedBalance = this.calculateInterest(value);
     this.setState({ estimatedFuture: estimatedBalance.toFixed(2) });
   }
 
@@ -204,8 +205,8 @@ class Creator extends Component {
                   size="sm"
                   type="radio"
                   name="options"
-                  defaultValue={1}
-                  onClick={this.changeEstValue}
+                  defaultValue="1"
+                  onChange={this.changeEstValue}
                 >
                   <ToggleButton value="1">1mo</ToggleButton>
                   <ToggleButton value="6">6mo</ToggleButton>

--- a/client/src/components/Creator.js
+++ b/client/src/components/Creator.js
@@ -136,7 +136,7 @@ class Creator extends Component {
             </Button>
           </div>
 
-          <div class="d-flex justify-content-center mt-4">
+          <div className="d-flex justify-content-center mt-4">
             <Card className="mr-4" style={{ width: "17rem" }}>
               <Card.Body>
                 <Card.Title>Your balance</Card.Title>
@@ -184,7 +184,7 @@ class Creator extends Component {
               </Card.Body>
             </Card>
           </div>
-          <div class="d-flex justify-content-center mt-4">
+          <div className="d-flex justify-content-center mt-4">
             <Card className="mr-4" style={{ width: "17rem" }}>
               <Card.Body>
                 <Card.Title>Interest rate</Card.Title>
@@ -215,7 +215,7 @@ class Creator extends Component {
               </Card.Body>
             </Card>
           </div>
-          <div class="d-flex justify-content-around mt-5 col-md-12">
+          <div className="d-flex justify-content-around mt-5 col-md-12">
             <h3> Recent Transactions </h3>
           </div>
           <div className="d-flex justify-content-around mt-5 col-md-12">

--- a/client/src/components/Creator.js
+++ b/client/src/components/Creator.js
@@ -52,8 +52,8 @@ class Creator extends Component {
     return estimatedBalance;
   }
 
-  changeEstValue(value) {
-    const estimatedBalance = this.calculateInterest(value);
+  changeEstValue(numMonths) {
+    const estimatedBalance = this.calculateInterest(numMonths);
     this.setState({ estimatedFuture: estimatedBalance.toFixed(2) });
   }
 


### PR DESCRIPTION
Sets the `defaultValue` as a raw value. `{1}` -> `"1"`, which fixes the issue.

- Preselect interest time on page load
- Fix remaining 'class' usage

Before (on first page load):
<img width="277" alt="Screen Shot 2021-02-07 at 1 40 01 AM" src="https://user-images.githubusercontent.com/2449384/107142690-74203780-68e5-11eb-9968-0962625343b5.png">

After:
<img width="287" alt="Screen Shot 2021-02-07 at 1 39 08 AM" src="https://user-images.githubusercontent.com/2449384/107142686-71bddd80-68e5-11eb-84ba-469cdcb5ea77.png">

